### PR TITLE
Rewrite plugin paths for remote jobs

### DIFF
--- a/client/arg.cpp
+++ b/client/arg.cpp
@@ -612,8 +612,13 @@ bool analyse_argv(const char * const *argv, CompileJob &job, bool icerun, list<s
                             string file = argv[i + 2];
 
                             if (access(file.c_str(), R_OK) == 0) {
-                                file = get_absfilename(file);
-                                extrafiles->push_back(file);
+                                // Leave the file as it is, the path will be rewritten
+                                // later (for remote jobs).
+                                // See CompileJob::rewritePluginPaths()
+                                // file = get_absfilename(file);
+
+                                // Do not send the plugin with each job
+                                // extrafiles->push_back(file);
                             } else {
                                 always_local = true;
                                 log_info() << "plugin for argument "

--- a/client/remote.cpp
+++ b/client/remote.cpp
@@ -750,6 +750,8 @@ static int minimalRemoteVersion( const CompileJob& job)
 
 int build_remote(CompileJob &job, MsgChannel *local_daemon, const Environments &_envs, int permill)
 {
+    job.rewritePluginPathsForRemoteJob();
+
     srand(time(0) + getpid());
 
     int torepeat = 1;

--- a/services/job.h
+++ b/services/job.h
@@ -119,6 +119,9 @@ public:
     {
         m_flags = flags;
     }
+
+    void rewritePluginPathsForRemoteJob();
+
     std::list<std::string> localFlags() const;
     std::list<std::string> remoteFlags() const;
     std::list<std::string> restFlags() const;


### PR DESCRIPTION
Also, do not send plugin binaries with each job.